### PR TITLE
3 Scroll sometimes and setSelection() some kind of fix

### DIFF
--- a/lib/src/quill_editor_wrapper.dart
+++ b/lib/src/quill_editor_wrapper.dart
@@ -495,7 +495,6 @@ class QuillHtmlEditorState extends State<QuillHtmlEditor> {
         }     
         #scrolling-container {  
           min-height: ${widget.minHeight}px !important;
-          overflow-y: scroll  !important;
           -webkit-user-select: text !important;
          } 
         </style>
@@ -520,7 +519,7 @@ class QuillHtmlEditorState extends State<QuillHtmlEditor> {
         
         <!-- Create the editor container -->
         <div style="position:relative;margin-top:0em;">
-        <div id="editorcontainer" style= "min-height:${widget.minHeight}px; overflow-y:scroll;margin-top:0em;">
+        <div id="editorcontainer" style= "min-height:${widget.minHeight}px; margin-top:0em;">
         <div id="editor" style="min-height:${widget.minHeight}px; width:100%; height: ${widget.minHeight}px"></div>
         </div>
         </div> 

--- a/lib/src/quill_editor_wrapper.dart
+++ b/lib/src/quill_editor_wrapper.dart
@@ -521,7 +521,7 @@ class QuillHtmlEditorState extends State<QuillHtmlEditor> {
         <!-- Create the editor container -->
         <div style="position:relative;margin-top:0em;">
         <div id="editorcontainer" style= "min-height:${widget.minHeight}px; overflow-y:scroll;margin-top:0em;">
-        <div id="editor" style="min-height:${widget.minHeight}px; width:100%;"></div>
+        <div id="editor" style="min-height:${widget.minHeight}px; width:100%; height: ${widget.minHeight}px"></div>
         </div>
         </div> 
         </div>
@@ -685,7 +685,6 @@ class QuillHtmlEditorState extends State<QuillHtmlEditor> {
                 }
               },
               theme: 'snow',
-             scrollingContainer: '#scrolling-container', 
               placeholder: '${widget.hintText ?? "Description"}',
               clipboard: {
                 matchVisual: true
@@ -851,7 +850,8 @@ class QuillHtmlEditorState extends State<QuillHtmlEditor> {
             }
             
             function setSelection(index, length) {
-              setTimeout(() => quilleditor.setSelection(index, length), 1);
+              setTimeout(() => quilleditor.setSelection(index, length), 10);
+              setTimeout(() => quilleditor.focus(), 1000);
               return '';
             }
             


### PR DESCRIPTION
When there was no height, setSelection could not works properly. So I added height to <div id="editor">, and I added `setTimeout(() => quilleditor.focus(), 1000);`after setSelection.

Now you can just give height from main widget, like this

```
QuillHtmlEditor(
    controller: controller,
    minHeight:
        MediaQuery.of(context).size.height -
            300,
)
```
Also  I tried to make unvisible 3 scroll.