### PR TITLE
Fix bug double new lines after press return on Android

### DIFF
--- a/lib/src/quill_editor_wrapper.dart
+++ b/lib/src/quill_editor_wrapper.dart
@@ -858,7 +858,7 @@ class QuillHtmlEditorState extends State<QuillHtmlEditor> {
                 }
                 editor.applyGoogleKeyboardWorkaround = true
                 editor.on('editor-change', function(eventName, ...args) {
-                  
+                  try {
                     // args[0] will be delta
                     var ops = args[0]['ops']
                     if(ops === null) {
@@ -870,7 +870,7 @@ class QuillHtmlEditorState extends State<QuillHtmlEditor> {
                     if( ops[0]["retain"] === undefined || !ops[1] || !ops[1]["insert"] || !ops[1]["insert"] || ops[1]["list"] === "bullet" || ops[1]["list"] === "ordered" || ops[1]["insert"] != "\\n" || oldSelectionLength > 0) {
                       return
                     }
-                 
+                    
                     setTimeout(function() {
                       var newPos = editor.getSelection(true).index
                       if(newPos === oldPos) {
@@ -879,7 +879,9 @@ class QuillHtmlEditorState extends State<QuillHtmlEditor> {
                       }
                     }, 30);
                     //onRangeChanged();
-                 
+                  } catch(e) {
+                    console.log('applyGoogleKeyboardWorkaround - editor-change', e);
+                  }
                 });
               } catch(e) {
                 console.log('applyGoogleKeyboardWorkaround', e);


### PR DESCRIPTION
Here's the issue
https://github.com/the-airbender/quill_html_editor/issues/126

Cause by exception being thrown in 'editor-change' event handler.